### PR TITLE
Change sample code's view models to implement Observer pattern

### DIFF
--- a/Example/CascadingTableDelegate.xcodeproj/project.pbxproj
+++ b/Example/CascadingTableDelegate.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		8D50BE781DC8535F00B0C427 /* DestinationMapCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D50BE761DC8535F00B0C427 /* DestinationMapCell.xib */; };
 		8D754B901D6B103400A1DE01 /* CascadingTableDelegateCompleteStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D754B8F1D6B103400A1DE01 /* CascadingTableDelegateCompleteStub.swift */; };
 		8D9E13AC1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9E13AB1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift */; };
+		8D9E13AE1DCC7E1B0040F2E5 /* DestinationHeaderSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9E13AD1DCC7E1B0040F2E5 /* DestinationHeaderSectionViewModel.swift */; };
 		8DDD582A1DC8C8DE00328981 /* DestinationReviewRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDD58281DC8C8DE00328981 /* DestinationReviewRatingCell.swift */; };
 		8DDD582B1DC8C8DE00328981 /* DestinationReviewRatingCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DDD58291DC8C8DE00328981 /* DestinationReviewRatingCell.xib */; };
 		A5158932822D6A8BA58CC3B3 /* Pods_CascadingTableDelegate_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0A465F97314BF19FD1CD61 /* Pods_CascadingTableDelegate_Example.framework */; };
@@ -140,6 +141,7 @@
 		8D50BE761DC8535F00B0C427 /* DestinationMapCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DestinationMapCell.xib; sourceTree = "<group>"; };
 		8D754B8F1D6B103400A1DE01 /* CascadingTableDelegateCompleteStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CascadingTableDelegateCompleteStub.swift; sourceTree = "<group>"; };
 		8D9E13AB1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationReviewSectionViewModel.swift; sourceTree = "<group>"; };
+		8D9E13AD1DCC7E1B0040F2E5 /* DestinationHeaderSectionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationHeaderSectionViewModel.swift; sourceTree = "<group>"; };
 		8DDD58281DC8C8DE00328981 /* DestinationReviewRatingCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationReviewRatingCell.swift; sourceTree = "<group>"; };
 		8DDD58291DC8C8DE00328981 /* DestinationReviewRatingCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DestinationReviewRatingCell.xib; sourceTree = "<group>"; };
 		8F0A465F97314BF19FD1CD61 /* Pods_CascadingTableDelegate_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CascadingTableDelegate_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -368,6 +370,7 @@
 			children = (
 				8D4FD7671DCA1E2D00F42211 /* DestinationInfoSectionViewModel.swift */,
 				8D9E13AB1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift */,
+				8D9E13AD1DCC7E1B0040F2E5 /* DestinationHeaderSectionViewModel.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				8D4FD75B1DC9A9BA00F42211 /* ReviewSectionFooterView.swift in Sources */,
 				8D4D12C91DC708CC00B273F9 /* DestinationTopPhotoCell.swift in Sources */,
 				8D4FD76E1DCA2E0D00F42211 /* EmptyContentView.swift in Sources */,
+				8D9E13AE1DCC7E1B0040F2E5 /* DestinationHeaderSectionViewModel.swift in Sources */,
 				8D4D12D91DC7194B00B273F9 /* DestinationDescriptionCell.swift in Sources */,
 				8D50BE771DC8535F00B0C427 /* DestinationMapCell.swift in Sources */,
 				8D3749D91DC8CEE3001DEED7 /* DestinationReviewRatingSectionDelegate.swift in Sources */,

--- a/Example/CascadingTableDelegate.xcodeproj/project.pbxproj
+++ b/Example/CascadingTableDelegate.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		8D50BE771DC8535F00B0C427 /* DestinationMapCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D50BE751DC8535F00B0C427 /* DestinationMapCell.swift */; };
 		8D50BE781DC8535F00B0C427 /* DestinationMapCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D50BE761DC8535F00B0C427 /* DestinationMapCell.xib */; };
 		8D754B901D6B103400A1DE01 /* CascadingTableDelegateCompleteStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D754B8F1D6B103400A1DE01 /* CascadingTableDelegateCompleteStub.swift */; };
+		8D9E13AC1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9E13AB1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift */; };
 		8DDD582A1DC8C8DE00328981 /* DestinationReviewRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDD58281DC8C8DE00328981 /* DestinationReviewRatingCell.swift */; };
 		8DDD582B1DC8C8DE00328981 /* DestinationReviewRatingCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8DDD58291DC8C8DE00328981 /* DestinationReviewRatingCell.xib */; };
 		A5158932822D6A8BA58CC3B3 /* Pods_CascadingTableDelegate_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F0A465F97314BF19FD1CD61 /* Pods_CascadingTableDelegate_Example.framework */; };
@@ -138,6 +139,7 @@
 		8D50BE751DC8535F00B0C427 /* DestinationMapCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationMapCell.swift; sourceTree = "<group>"; };
 		8D50BE761DC8535F00B0C427 /* DestinationMapCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DestinationMapCell.xib; sourceTree = "<group>"; };
 		8D754B8F1D6B103400A1DE01 /* CascadingTableDelegateCompleteStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CascadingTableDelegateCompleteStub.swift; sourceTree = "<group>"; };
+		8D9E13AB1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationReviewSectionViewModel.swift; sourceTree = "<group>"; };
 		8DDD58281DC8C8DE00328981 /* DestinationReviewRatingCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationReviewRatingCell.swift; sourceTree = "<group>"; };
 		8DDD58291DC8C8DE00328981 /* DestinationReviewRatingCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DestinationReviewRatingCell.xib; sourceTree = "<group>"; };
 		8F0A465F97314BF19FD1CD61 /* Pods_CascadingTableDelegate_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CascadingTableDelegate_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -365,6 +367,7 @@
 			isa = PBXGroup;
 			children = (
 				8D4FD7671DCA1E2D00F42211 /* DestinationInfoSectionViewModel.swift */,
+				8D9E13AB1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -656,6 +659,7 @@
 				8D4FD76C1DCA20B100F42211 /* DestinationInfoListSectionDelegate.swift in Sources */,
 				8D4D12D61DC7191E00B273F9 /* String+DisplayHeight.swift in Sources */,
 				8D4FD76A1DCA1EF300F42211 /* DestinationInfoListRowDelegate.swift in Sources */,
+				8D9E13AC1DCC69F40040F2E5 /* DestinationReviewSectionViewModel.swift in Sources */,
 				8D1BCAA91DC33ED900826B1D /* WelcomeViewController.swift in Sources */,
 				8DDD582A1DC8C8DE00328981 /* DestinationReviewRatingCell.swift in Sources */,
 				8D4FD7601DC9ADC000F42211 /* UIView+RoundedCorner.swift in Sources */,

--- a/Example/CascadingTableDelegate/Protocols/DestinationHeaderSectionViewModel.swift
+++ b/Example/CascadingTableDelegate/Protocols/DestinationHeaderSectionViewModel.swift
@@ -1,0 +1,58 @@
+//
+//  DestinationHeaderSectionViewModel.swift
+//  CascadingTableDelegate
+//
+//  Created by Ricardo Pramana Suranta on 11/4/16.
+//  Copyright © 2016 Ricardo Pramana Suranta. All rights reserved.
+//
+
+import UIKit
+
+protocol DestinationHeaderSectionViewModelObserver: class {
+	
+	/// Executed when any property info of the observed `DestinationHeaderSectionViewModel` is updated.
+	func headerSectionDataChanged()
+}
+
+protocol DestinationHeaderSectionViewModel: class {
+	
+	var topPhoto: UIImage? { get }
+	
+	var destinationName: String? { get }
+	var locationName: String? { get }
+	
+	var description: String? { get }
+	
+	/// `DestinationHeaderSectionViewModelObserver`s of this instance.
+	var headerSectionObservers: [DestinationHeaderSectionViewModelObserver] { get set }
+}
+
+extension DestinationHeaderSectionViewModel {
+	
+	/// Add passed `observer` to this instance's `headerSectionObservers`.
+	func add(observer: DestinationHeaderSectionViewModelObserver) {
+		self.headerSectionObservers.append(observer)
+	}
+	
+	/// Remove passed `observer` from this instance's `headerSectionObservers`.
+	func remove(observer: DestinationHeaderSectionViewModelObserver) {
+		
+		let observerIndex = self.headerSectionObservers.index { anotherObserver -> Bool in
+			
+			return observer === anotherObserver
+		}
+		
+		if let index = observerIndex {
+			self.headerSectionObservers.remove(at: index)
+		}
+	}
+	
+	/// Notify each of this `headerSectionObservers`' `headerSectionDataChanged()`.
+	func notifyHeaderSectionObservers() {
+		
+		self.headerSectionObservers.forEach { observer in
+			observer.headerSectionDataChanged()
+		}
+	}
+	
+}

--- a/Example/CascadingTableDelegate/Protocols/DestinationHeaderSectionViewModel.swift
+++ b/Example/CascadingTableDelegate/Protocols/DestinationHeaderSectionViewModel.swift
@@ -47,7 +47,7 @@ extension DestinationHeaderSectionViewModel {
 		}
 	}
 	
-	/// Notify each of this `headerSectionObservers`' `headerSectionDataChanged()`.
+	/// Call each of this `headerSectionObservers`' `headerSectionDataChanged()`.
 	func notifyHeaderSectionObservers() {
 		
 		self.headerSectionObservers.forEach { observer in

--- a/Example/CascadingTableDelegate/Protocols/DestinationInfoSectionViewModel.swift
+++ b/Example/CascadingTableDelegate/Protocols/DestinationInfoSectionViewModel.swift
@@ -16,7 +16,7 @@ struct DestinationInfo {
 
 protocol DestinationInfoSectionViewModelObserver: class {
 	
-	/// Executed when any property info of the listened `DestinationInfoSectionViewModel` is updated.
+	/// Executed when any property info of the observed `DestinationInfoSectionViewModel` is updated.
 	func infoSectionDataChanged()
 }
 
@@ -34,10 +34,12 @@ protocol DestinationInfoSectionViewModel: class {
 
 extension DestinationInfoSectionViewModel {
 	
+	/// Add passed `observer` to this instance's `infoSectionObservers`.
 	func add(observer: DestinationInfoSectionViewModelObserver) {
 		self.infoSectionObservers.append(observer)
 	}
 	
+	/// Remove passed `observer` from this instance's `infoSectionObservers`.
 	func remove(observer: DestinationInfoSectionViewModelObserver) {
 		
 		let observerIndex = self.infoSectionObservers.index { (anotherObserver) -> Bool in
@@ -50,8 +52,7 @@ extension DestinationInfoSectionViewModel {
 		}
 	}
 	
-	
-	/// Notify all
+	/// Notify each of this `reviewSectionObservers`' `reviewSectionDataChanged()`.
 	func notifyInfoSectionObservers() {
 		self.infoSectionObservers.forEach { observer in
 			observer.infoSectionDataChanged()

--- a/Example/CascadingTableDelegate/Protocols/DestinationReviewSectionViewModel.swift
+++ b/Example/CascadingTableDelegate/Protocols/DestinationReviewSectionViewModel.swift
@@ -52,7 +52,7 @@ extension DestinationReviewSectionViewModel {
 		}
 	}
 	
-	/// Notify each of this `reviewSectionObservers`' `reviewSectionDataChanged()`.
+	/// Call each of this `reviewSectionObservers`' `reviewSectionDataChanged()`.
 	func notifyReviewSectionObservers() {
 		
 		self.reviewSectionObservers.forEach { observer in

--- a/Example/CascadingTableDelegate/Protocols/DestinationReviewSectionViewModel.swift
+++ b/Example/CascadingTableDelegate/Protocols/DestinationReviewSectionViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  DestinationReviewSectionViewModel.swift
+//  CascadingTableDelegate
+//
+//  Created by Ricardo Pramana Suranta on 11/4/16.
+//  Copyright © 2016 Ricardo Pramana Suranta. All rights reserved.
+//
+
+import Foundation
+
+protocol DestinationReviewSectionViewModelObserver: class {
+	
+	/// Executed when any property info of the observed `DestinationReviewSectionViewModel` is updated.
+	func reviewSectionDataChanged()
+}
+
+protocol DestinationReviewSectionViewModel: class {
+	
+	/// Average rating of all reviews.
+	var averageRating: Int { get }
+	
+	/// Array of `DestinationReviewUserRowViewModel` that stores user reviews.
+	var rowViewModels: [DestinationReviewUserRowViewModel] { get }
+	
+	/// Number of `DestinationReviewUserRowViewModel` that haven't retrived yet, and available to be retreived via `retrieveMoreRowViewModels`.
+	var remainingRowViewModels: Int { get }
+	
+	/// `DestinationReviewSectionViewModelObserver`s of this instance.
+	var reviewSectionObservers: [DestinationReviewSectionViewModelObserver] { get set }
+	
+	/// Retrieve more rows and add it to `rowViewModels`, then execute `onCompleted` when it's ready.
+	func retrieveMoreRowViewModels(_ onCompleted: ((Void) -> Void)?)
+}
+
+extension DestinationReviewSectionViewModel {
+
+	/// Add passed `observer` to this instance's `reviewSectionObservers`.
+	func add(observer: DestinationReviewSectionViewModelObserver) {
+		self.reviewSectionObservers.append(observer)
+	}
+	
+	/// Remove passed `observer` from this instance's `reviewSectionObservers`.
+	func remove(observer: DestinationReviewSectionViewModelObserver) {
+	
+		let observerIndex = self.reviewSectionObservers.index { anotherObserver -> Bool in
+			
+			return observer === anotherObserver
+		}
+		
+		if let index = observerIndex {
+			self.reviewSectionObservers.remove(at: index)
+		}
+	}
+	
+	/// Notify each of this `reviewSectionObservers`' `reviewSectionDataChanged()`.
+	func notifyReviewSectionObservers() {
+		
+		self.reviewSectionObservers.forEach { observer in
+			observer.reviewSectionDataChanged()
+		}
+	}
+	
+}

--- a/Example/CascadingTableDelegate/SectionTableDelegates/DestinationHeaderSectionDelegate.swift
+++ b/Example/CascadingTableDelegate/SectionTableDelegates/DestinationHeaderSectionDelegate.swift
@@ -9,19 +9,6 @@
 import UIKit
 import CascadingTableDelegate
 
-protocol DestinationHeaderSectionViewModel: class {
-	
-	var topPhoto: UIImage? { get }
-	
-	var destinationName: String? { get }
-	var locationName: String? { get }
-	
-	var description: String? { get }
-	
-	/// Executed when any of this instance's header-related property updated.
-	var headerDataChanged: ((Void) -> Void)? { get set }
-}
-
 class DestinationHeaderSectionDelegate: NSObject {
 
 	enum Row: Int {

--- a/Example/CascadingTableDelegate/SectionTableDelegates/DestinationHeaderSectionDelegate.swift
+++ b/Example/CascadingTableDelegate/SectionTableDelegates/DestinationHeaderSectionDelegate.swift
@@ -29,19 +29,16 @@ class DestinationHeaderSectionDelegate: NSObject {
 	var childDelegates: [CascadingTableDelegate]
 	weak var parentDelegate: CascadingTableDelegate?
 	
-	var viewModel: DestinationHeaderSectionViewModel? {
-		didSet {
-			configureViewModelObserver()
-			currentTableView?.reloadData()
-		}
-	}
+	fileprivate var viewModel: DestinationHeaderSectionViewModel?
 	
 	fileprivate weak var currentTableView: UITableView?
 	
 	convenience init(viewModel: DestinationHeaderSectionViewModel? = nil) {
+		
 		self.init(index: 0, childDelegates: [])
+		
+		viewModel?.add(observer: self)
 		self.viewModel = viewModel
-		configureViewModelObserver()
 	}
 	
 	required init(index: Int, childDelegates: [CascadingTableDelegate]) {
@@ -49,20 +46,22 @@ class DestinationHeaderSectionDelegate: NSObject {
 		self.childDelegates = childDelegates
 	}
 	
-	// MARK: - Private methods
+	deinit {
+		viewModel?.remove(observer: self)
+	}
 	
-	fileprivate func configureViewModelObserver() {
+}
 
-		viewModel?.headerDataChanged = { [weak self] in
-			
-			guard let index = self?.index,
-				let tableView = self?.currentTableView else {
+extension DestinationHeaderSectionDelegate: DestinationHeaderSectionViewModelObserver {
+
+	func headerSectionDataChanged() {
+		
+		guard let tableView = currentTableView else {
 				return
-			}
-			
-			let indexes = IndexSet(integer: index)
-			tableView.reloadSections(indexes, with: .automatic)
 		}
+		
+		let indexes = IndexSet(integer: index)
+		tableView.reloadSections(indexes, with: .automatic)
 	}
 }
 

--- a/Example/CascadingTableDelegate/SectionTableDelegates/DestinationReviewRatingSectionDelegate.swift
+++ b/Example/CascadingTableDelegate/SectionTableDelegates/DestinationReviewRatingSectionDelegate.swift
@@ -9,13 +9,6 @@
 import Foundation
 import CascadingTableDelegate
 
-protocol DestinationReviewRatingSectionViewModel: class {
-	
-	var averageRating: Int { get }
-	
-	/// Executed when this instance's review rating data is updated.
-	var reviewRatingDataUpdated: ((Void) -> Void)? { get set }
-}
 
 class DestinationReviewRatingSectionDelegate: NSObject {
 	
@@ -23,19 +16,18 @@ class DestinationReviewRatingSectionDelegate: NSObject {
 	var childDelegates: [CascadingTableDelegate]
 	weak var parentDelegate: CascadingTableDelegate?
 	
-	var viewModel: DestinationReviewRatingSectionViewModel? {
-		didSet {
-			configureViewModelObserver()
-		}
-	}
+	fileprivate var viewModel: DestinationReviewSectionViewModel?
 	
 	fileprivate var headerview: SectionHeaderView
 	fileprivate weak var currentTableView: UITableView?
 	
-	convenience init(viewModel: DestinationReviewRatingSectionViewModel? = nil) {
+	convenience init(viewModel: DestinationReviewSectionViewModel? = nil) {
 		self.init(index: 0, childDelegates: [])
+		
+		
+		viewModel?.add(observer: self)
 		self.viewModel = viewModel
-		configureViewModelObserver()
+		
 	}
 	
 	required init(index: Int, childDelegates: [CascadingTableDelegate]) {
@@ -46,19 +38,20 @@ class DestinationReviewRatingSectionDelegate: NSObject {
 		headerview = SectionHeaderView.view(headerText: "REVIEW")
 	}
 	
-	fileprivate func configureViewModelObserver() {
+}
+
+extension DestinationReviewRatingSectionDelegate: DestinationReviewSectionViewModelObserver {
+	
+	func reviewSectionDataChanged() {
 		
-		viewModel?.reviewRatingDataUpdated = { [weak self] in
-			
-			guard let index = self?.index,
-				let tableView = self?.currentTableView else {
+		guard let tableView = currentTableView else {
 				return
-			}
-			
-			let indexes = IndexSet(integer: index)
-			tableView.reloadSections(indexes, with: .automatic)			
 		}
+		
+		let indexes = IndexSet(integer: index)
+		tableView.reloadSections(indexes, with: .automatic)
 	}
+	
 }
 
 extension DestinationReviewRatingSectionDelegate: CascadingTableDelegate {

--- a/Example/CascadingTableDelegate/ViewControllers/DestinationViewController.swift
+++ b/Example/CascadingTableDelegate/ViewControllers/DestinationViewController.swift
@@ -80,6 +80,8 @@ class DestinationViewController: UIViewController {
 
 	fileprivate func createRootDelegate() {				
 		
+		// Feel free to remove, add, copy, or change this array's value. The rootTableDelegate will do the heavy-lifting and display the correct result for you :)
+		
 		let childDelegates: [CascadingTableDelegate] = [
 			DestinationHeaderSectionDelegate(viewModel: viewModel),
 			DestinationInfoMapSectionDelegate(viewModel: viewModel),

--- a/Example/CascadingTableDelegate/ViewModels/DestinationViewModel.swift
+++ b/Example/CascadingTableDelegate/ViewModels/DestinationViewModel.swift
@@ -15,9 +15,8 @@ class DestinationViewModel {
 	
 	var destinationTitle: String?
 	var headerDataChanged: ((Void) -> Void)?
-	var reviewRatingDataUpdated: ((Void) -> Void)?
-	var reviewUserDataChanged: ((Void) -> Void)?
 	
+	var reviewSectionObservers = [DestinationReviewSectionViewModelObserver]()
 	var infoSectionObservers = [DestinationInfoSectionViewModelObserver]()
 	
 	// MARK: - Private properties
@@ -104,9 +103,8 @@ class DestinationViewModel {
 	fileprivate func executeUpdateClosures() {
 				
 		headerDataChanged?()
-		reviewRatingDataUpdated?()
-		reviewUserDataChanged?()
 		
+		notifyReviewSectionObservers()		
 		notifyInfoSectionObservers()
 	}
 }
@@ -143,15 +141,13 @@ extension DestinationViewModel: DestinationInfoSectionViewModel {
 	
 }
 
-extension DestinationViewModel: DestinationReviewRatingSectionViewModel {
+
+extension DestinationViewModel: DestinationReviewSectionViewModel {
+
 	
 	var averageRating: Int {
 		return _averageRating
 	}
-	
-}
-
-extension DestinationViewModel: DestinationReviewUserSectionViewModel {
 	
 	var rowViewModels: [DestinationReviewUserRowViewModel] {
 
@@ -172,7 +168,7 @@ extension DestinationViewModel: DestinationReviewUserSectionViewModel {
 			self.generateMoreRowViewModels()
 			
 			DispatchQueue.main.async(execute: {
-				self.reviewUserDataChanged?()
+				self.notifyReviewSectionObservers()
 				onCompleted?()
 			})
 		}

--- a/Example/CascadingTableDelegate/ViewModels/DestinationViewModel.swift
+++ b/Example/CascadingTableDelegate/ViewModels/DestinationViewModel.swift
@@ -183,7 +183,7 @@ extension DestinationViewModel: DestinationReviewSectionViewModel {
 			rating: 4
 		)
 		
-		let newReviews = [DestinationReviewUserRowViewModel](repeating: userReview, count: 2)
+		let newReviews = [DestinationReviewUserRowViewModel](repeating: userReview, count: remainingRowViewModels)
 		
 		_rowViewModels.append(contentsOf: newReviews)
 		_remainingRowViewModels = 0

--- a/Example/CascadingTableDelegate/ViewModels/DestinationViewModel.swift
+++ b/Example/CascadingTableDelegate/ViewModels/DestinationViewModel.swift
@@ -14,8 +14,8 @@ class DestinationViewModel {
 	// MARK: - Public properties
 	
 	var destinationTitle: String?
-	var headerDataChanged: ((Void) -> Void)?
 	
+	var headerSectionObservers = [DestinationHeaderSectionViewModelObserver]()
 	var reviewSectionObservers = [DestinationReviewSectionViewModelObserver]()
 	var infoSectionObservers = [DestinationInfoSectionViewModelObserver]()
 	
@@ -101,9 +101,8 @@ class DestinationViewModel {
 	}
 	
 	fileprivate func executeUpdateClosures() {
-				
-		headerDataChanged?()
 		
+		notifyHeaderSectionObservers()
 		notifyReviewSectionObservers()		
 		notifyInfoSectionObservers()
 	}

--- a/Example/CascadingTableDelegate/Views/ReviewSectionFooterView.xib
+++ b/Example/CascadingTableDelegate/Views/ReviewSectionFooterView.xib
@@ -8,11 +8,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReviewSectionFooterView" customModule="CascadingTableDelegate_Example" customModuleProvider="target">
+        <view clipsSubviews="YES" contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReviewSectionFooterView" customModule="CascadingTableDelegate_Example" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="600" height="199"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5dG-Um-yar" userLabel="Wrapper View">
+                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5dG-Um-yar" userLabel="Wrapper View">
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oPD-n5-b2Y" userLabel="Custom Top Border View">
                             <color key="backgroundColor" red="0.30980393290519714" green="0.37254902720451355" blue="0.43529412150382996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Instead of using a property closure that can only be set by an instance, Observer pattern will match the nature of the sample view models better. With it, those who tried the sample page could copy the section delegates and still see the section drawn properly :)