### PR TITLE
Add `pod install` step in `run_tests.sh`

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,4 @@
+pod install --project-directory=Example
 xcodebuild \
   -workspace Example/CascadingTableDelegate.xcworkspace \
   -scheme CascadingTableDelegate-Example \


### PR DESCRIPTION
Since the Pods directory is removed, there's a chance that the test Pods is not available when testing. Adding `pod install` step fixes that.